### PR TITLE
Make sure the start script is executable

### DIFF
--- a/src/main/kotlin/org/web3j/container/KGenericContainer.kt
+++ b/src/main/kotlin/org/web3j/container/KGenericContainer.kt
@@ -34,7 +34,7 @@ open class KGenericContainer(
         resolveGenesis()
         withLogConsumer { println(it.utf8String) }
         withExposedPorts(8545)
-        withCopyFileToContainer(MountableFile.forClasspathResource(startUpScript), "/start.sh")
+        withCopyFileToContainer(MountableFile.forClasspathResource(startUpScript, 755), "/start.sh")
         resourceFiles.forEach { (source, target) ->
             withCopyFileToContainer(MountableFile.forClasspathResource(source), target)
         }


### PR DESCRIPTION
When external projects depend on web3j-unit, the script file within the web3j-unit jar isn't executable by default.