### PR TITLE
Use TestWatcher and context from PassthroughTracer to print solidity …

### DIFF
--- a/src/main/kotlin/org/web3j/container/embedded/EmbeddedService.kt
+++ b/src/main/kotlin/org/web3j/container/embedded/EmbeddedService.kt
@@ -18,7 +18,7 @@ import org.web3j.evm.Configuration
 import org.web3j.evm.EmbeddedWeb3jService
 import org.web3j.protocol.Web3jService
 
-class EmbeddedService(private val configuration: Configuration, private val operationTracer: OperationTracer) : GenericService {
+class EmbeddedService(val configuration: Configuration, val operationTracer: OperationTracer) : GenericService {
     override fun startService(): Web3jService {
         return EmbeddedWeb3jService(configuration, operationTracer)
     }


### PR DESCRIPTION
…source code location at test failure.

Example output on failed test:

Testing started at 16:47 ...
> Task :test
2019-12-16 16:47:36.047+00:00 [Test worker] INFO  o.h.b.e.m.ProtocolScheduleBuilder Protocol schedule created with milestones: [Frontier: 0, Homestead: 1150000, DaoRecoveryInit: 1920000, DaoRecoveryTransition: 1920001, Homestead: 1920010, TangerineWhistle: 2463000, SpuriousDragon: 2675000, Byzantium: 4370000, ConstantinopleFix: 7280000]
At solidity source location 182:89:0:

    function getGreeting() public constant returns (string)  {
        return greeting;
    }
}

expected: <Hello Blockchain World! 1> but was: <Hello Blockchain World!>
org.opentest4j.AssertionFailedError: expected: <Hello Blockchain World! 1> but was: <Hello Blockchain World!>
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
	at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
	at org.web3j.unitexample.GreeterEmbeddedTest.helloWorldTest(GreeterEmbeddedTest.java:25)
