### PR TITLE
Added possibility to specify a genesis file to Embedded Ethereum

### DIFF
--- a/src/main/kotlin/org/web3j/container/ServiceBuilder.kt
+++ b/src/main/kotlin/org/web3j/container/ServiceBuilder.kt
@@ -71,7 +71,7 @@ class ServiceBuilder {
             NodeType.PARITY -> throw RuntimeException("Container Type Not Supported: $type")
             NodeType.EMBEDDED -> {
                 if (genesisPath == "dev")
-                    EmbeddedService(Configuration(Address(selfAddress), 10, null), PassthroughTracer())
+                    EmbeddedService(Configuration(Address(selfAddress), 10), PassthroughTracer())
                 else
                     EmbeddedService(Configuration(Address(selfAddress), 10, URL(genesisPath)), PassthroughTracer())
             }

--- a/src/main/kotlin/org/web3j/container/ServiceBuilder.kt
+++ b/src/main/kotlin/org/web3j/container/ServiceBuilder.kt
@@ -20,6 +20,7 @@ import org.web3j.container.geth.GethContainer
 import org.web3j.container.embedded.EmbeddedService
 import org.web3j.evm.Configuration
 import org.web3j.evm.PassthroughTracer
+import java.net.URL
 
 class ServiceBuilder {
 
@@ -68,7 +69,12 @@ class ServiceBuilder {
             NodeType.BESU -> BesuContainer(version, resourceFiles, hostFiles, genesisPath)
             NodeType.GETH -> GethContainer(version, resourceFiles, hostFiles, genesisPath)
             NodeType.PARITY -> throw RuntimeException("Container Type Not Supported: $type")
-            NodeType.EMBEDDED -> EmbeddedService(Configuration(Address(selfAddress), 10), PassthroughTracer())
+            NodeType.EMBEDDED -> {
+                if (genesisPath == "dev")
+                    EmbeddedService(Configuration(Address(selfAddress), 10, null), PassthroughTracer())
+                else
+                    EmbeddedService(Configuration(Address(selfAddress), 10, URL(genesisPath)), PassthroughTracer())
+            }
             NodeType.COMPOSE -> KDockerComposeContainer(dockerCompose, serviceName, containerPort)
         }
     }

--- a/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
+++ b/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
@@ -36,9 +36,7 @@ class EmbeddedGenesisTest {
 
     @Test
     fun genesisLoads(
-        web3j: Web3j,
-        transactionManager: TransactionManager,
-        gasProvider: ContractGasProvider
+        web3j: Web3j
     ) {
         val expectedAccountBalance = BigInteger.valueOf(2000)
         val actualAccountBalance = web3j.ethGetBalance("9811ebc35d7b06b3fa8dc5809a1f9c52751e1deb", DefaultBlockParameter.valueOf(BigInteger.ONE)).send()

--- a/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
+++ b/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.web3j.greeter.Greeter
+import org.web3j.protocol.Web3j
+import org.web3j.tx.TransactionManager
+import org.web3j.tx.gas.ContractGasProvider
+
+@EVMTest(type = NodeType.EMBEDDED, genesis = "file:src/test/resources/embedded/genesis.json")
+class EmbeddedGenesisTest {
+    @Test
+    fun greeterDeploys(
+        web3j: Web3j,
+        transactionManager: TransactionManager,
+        gasProvider: ContractGasProvider
+    ) {
+        val greeter = Greeter.deploy(web3j, transactionManager, gasProvider, "Hello EVM").send()
+        val greeting = greeter.greet().send()
+        Assertions.assertEquals("Hello EVM", greeting)
+    }
+}

--- a/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
+++ b/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
@@ -16,8 +16,10 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.web3j.greeter.Greeter
 import org.web3j.protocol.Web3j
+import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.tx.TransactionManager
 import org.web3j.tx.gas.ContractGasProvider
+import java.math.BigInteger
 
 @EVMTest(type = NodeType.EMBEDDED, genesis = "file:src/test/resources/embedded/genesis.json")
 class EmbeddedGenesisTest {
@@ -30,5 +32,17 @@ class EmbeddedGenesisTest {
         val greeter = Greeter.deploy(web3j, transactionManager, gasProvider, "Hello EVM").send()
         val greeting = greeter.greet().send()
         Assertions.assertEquals("Hello EVM", greeting)
+    }
+
+    @Test
+    fun genesisLoads(
+        web3j: Web3j,
+        transactionManager: TransactionManager,
+        gasProvider: ContractGasProvider
+    ) {
+        val expectedAccountBalance = BigInteger.valueOf(2000)
+        val actualAccountBalance = web3j.ethGetBalance("9811ebc35d7b06b3fa8dc5809a1f9c52751e1deb", DefaultBlockParameter.valueOf(BigInteger.ONE)).send()
+
+        Assertions.assertEquals(expectedAccountBalance, actualAccountBalance.balance)
     }
 }

--- a/src/test/resources/embedded/genesis.json
+++ b/src/test/resources/embedded/genesis.json
@@ -1,4 +1,9 @@
 {
   "gasLimit": "0x1fffffffffffff",
-  "difficulty": "0x1"
+  "difficulty": "0x1",
+  "alloc": {
+    "9811ebc35d7b06b3fa8dc5809a1f9c52751e1deb": {
+      "balance": "2000"
+    }
+  }
 }

--- a/src/test/resources/embedded/genesis.json
+++ b/src/test/resources/embedded/genesis.json
@@ -1,0 +1,4 @@
+{
+  "gasLimit": "0x1fffffffffffff",
+  "difficulty": "0x1"
+}


### PR DESCRIPTION
This PR solves the #24 issue.

The issue is about being able to specify a genesis file path to Embedded Ethereum, or else use a pre-generated one. 