### PR TITLE
Fixing EmbeddedGenesisTest

### DIFF
--- a/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
+++ b/src/test/kotlin/org/web3j/EmbeddedGenesisTest.kt
@@ -13,7 +13,6 @@
 package org.web3j
 
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.web3j.greeter.Greeter
 import org.web3j.protocol.Web3j
@@ -24,7 +23,6 @@ import java.math.BigInteger
 
 @EVMTest(type = NodeType.EMBEDDED, genesis = "file:src/test/resources/embedded/genesis.json")
 class EmbeddedGenesisTest {
-    @Disabled("Temporarily disabled: https://github.com/web3j/web3j-unit/issues/26")
     @Test
     fun greeterDeploys(
         web3j: Web3j,
@@ -40,8 +38,8 @@ class EmbeddedGenesisTest {
     fun genesisLoads(
         web3j: Web3j
     ) {
-        val expectedAccountBalance = BigInteger.valueOf(2000)
-        val actualAccountBalance = web3j.ethGetBalance("9811ebc35d7b06b3fa8dc5809a1f9c52751e1deb", DefaultBlockParameter.valueOf(BigInteger.ONE)).send()
+        val expectedAccountBalance = BigInteger.valueOf(16)
+        val actualAccountBalance = web3j.ethGetBalance("fe3b557e8fb62b89f4916b721be55ceb828dbd74", DefaultBlockParameter.valueOf(BigInteger.ONE)).send()
 
         Assertions.assertEquals(expectedAccountBalance, actualAccountBalance.balance)
     }

--- a/src/test/resources/embedded/genesis.json
+++ b/src/test/resources/embedded/genesis.json
@@ -1,9 +1,19 @@
 {
-  "gasLimit": "0x1fffffffffffff",
-  "difficulty": "0x1",
+  "config": {
+    "chainId": 999,
+    "constantinopleFixBlock": 0,
+    "ethash": {
+      "fixeddifficulty": 100
+    }
+  },
+  "gasLimit": "0x1000000",
+  "difficulty": "0x10000",
   "alloc": {
-    "9811ebc35d7b06b3fa8dc5809a1f9c52751e1deb": {
-      "balance": "2000"
+    "fe3b557e8fb62b89f4916b721be55ceb828dbd73": {
+      "balance": "0x83185ac03640000"
+    },
+    "fe3b557e8fb62b89f4916b721be55ceb828dbd74": {
+      "balance": "0x10"
     }
   }
 }


### PR DESCRIPTION
Fixes [issue-26](https://github.com/web3j/web3j-unit/issues/26):

- Adds missing fields in the embedded genesis file

- Creates a second account in the genesis file so that the `genesisLoads` test is able to check for its exact balance. The first is used for sending test transactions.