### PR TITLE
Script fix to run a Geth Node 

### DIFF
--- a/src/main/resources/geth/geth_start.sh
+++ b/src/main/resources/geth/geth_start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-geth --nousb init ./genesis.json
-geth --nousb account import /key.txt --password /password.txt
-geth --nousb --rpc --http.api "eth,net,web,txpool" --rpcaddr=0.0.0.0 --allow-insecure-unlock --unlock 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73 --password /password.txt --mine
+geth init ./genesis.json
+geth account import --password password.txt key.txt
+geth --http --http.api "eth,net,txpool" --http.addr=0.0.0.0 --allow-insecure-unlock --unlock 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73 --password /password.txt --mine --miner.etherbase 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73 --rpc.allow-unprotected-txs

--- a/src/test/resources/compose/geth/compose_start.sh
+++ b/src/test/resources/compose/geth/compose_start.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-geth --nousb init /geth/test.json
-geth --nousb account import /geth/key.txt --password /geth/password.txt
-geth --nousb --rpc --rpcaddr=0.0.0.0 --allow-insecure-unlock --unlock 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73 --password /geth/password.txt --mine
+geth init ./genesis.json
+geth account import --password password.txt key.txt
+geth --http --http.api "eth,net,txpool" --http.addr=0.0.0.0 --allow-insecure-unlock --unlock 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73 --password password.txt --mine --miner.etherbase 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73 --rpc.allow-unprotected-txs


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue of starting a GETH Node using @EVMTest(NodeType.GETH). It updates the geth cli commands to be compatible with GETH version used

Updates include

--rpc flag became --http flag
-- rpcaddr became --http.addr
-- nousb is deprecated
Set --miner.etherbase

### Where should the reviewer start?
Please look at the updates in the script files

### Why is it needed?
In order to solve issues such as this: [Issue](https://github.com/web3j/web3j-unit/issues/58)
